### PR TITLE
MBX-3578: Remove .md extension from license

### DIFF
--- a/mindbox_ios/ios/mindbox_ios.podspec
+++ b/mindbox_ios/ios/mindbox_ios.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 The implementation of 'mindbox' plugin for the iOS platform
                        DESC
   s.homepage         = 'https://mindbox.cloud/'
-  s.license          = { :file => '../LICENSE.md' }
+  s.license          = { :file => '../LICENSE' }
   s.author           = { 'Mindbox' => 'it@mindbox.ru' }
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'


### PR DESCRIPTION
[Flutter] Поправить название License.MD чтобы не было warning[#3578](https://github.com/mindbox-cloud/issues-web-mobile/issues/3578)