### PR TITLE
MBX-3601: Update Example App with new extension methods

### DIFF
--- a/example/flutter_example/ios/MindboxNotificationServiceExtension/NotificationService.swift
+++ b/example/flutter_example/ios/MindboxNotificationServiceExtension/NotificationService.swift
@@ -7,7 +7,6 @@
 
 import UserNotifications
 import MindboxNotifications
-import Mindbox
 
 class NotificationService: UNNotificationServiceExtension {
     
@@ -27,7 +26,7 @@ class NotificationService: UNNotificationServiceExtension {
     
     // We use UserDefaults to save push data for example purposes only. Don't use this solution for yourself
     func saveNotification(request: UNNotificationRequest) {
-        guard let pushData = Mindbox.shared.getMindboxPushData(userInfo: request.content.userInfo) else {
+        guard let pushData = mindboxService.getMindboxPushData(userInfo: request.content.userInfo) else {
             print("Failed to get Mindbox push data")
             return
         }

--- a/example/flutter_example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/flutter_example/ios/Runner.xcodeproj/project.pbxproj
@@ -950,7 +950,6 @@
 					"$(inherited)",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/MindboxLogger\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/MindboxNotifications\"",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/Mindbox\"",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1005,7 +1004,6 @@
 					"$(inherited)",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/MindboxLogger\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/MindboxNotifications\"",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/Mindbox\"",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1058,7 +1056,6 @@
 					"$(inherited)",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/MindboxLogger\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/MindboxNotifications\"",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/Mindbox\"",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/example/flutter_example/ios/Runner/AppDelegate.swift
+++ b/example/flutter_example/ios/Runner/AppDelegate.swift
@@ -65,7 +65,7 @@ import UserNotifications
     
     override func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         //Implement display of standard notifications
-        completionHandler([.list, .badge, .sound, .banner])
+        completionHandler([.alert, .badge, .sound])
         notifyFlutterNewData()
     }
     

--- a/example/flutter_example/ios/Runner/AppDelegate.swift
+++ b/example/flutter_example/ios/Runner/AppDelegate.swift
@@ -65,7 +65,7 @@ import UserNotifications
     
     override func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         //Implement display of standard notifications
-        completionHandler([.alert, .badge, .sound])
+        completionHandler([.list, .badge, .sound, .banner])
         notifyFlutterNewData()
     }
     


### PR DESCRIPTION
[iOS] Сделать доступными методы isMindboxPush и getMindboxPushData в MindboxNotifications[#3601](https://github.com/mindbox-cloud/issues-web-mobile/issues/3601)

Надо в рамках этого `PR` или отдельно, совмещая с этим, поднимать версии SDK здесь используемые в Example. Префаером не стал этого делать. 