### PR TITLE
GITLAB | change worfklow dispatch to gitlab

### DIFF
--- a/.github/workflows/trigger-build-app.yml
+++ b/.github/workflows/trigger-build-app.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   trigger:
     runs-on: macos-latest
-    if: github.event.pull_request.merged == true
+#    if: github.event.pull_request.merged == true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/trigger-build-app.yml
+++ b/.github/workflows/trigger-build-app.yml
@@ -1,11 +1,6 @@
 name: Build application after merge
 
-on:
-  pull_request:
-    types: [closed]
-    branches:
-      - 'feature/*'
-      - 'develop'
+on: push
 
 jobs:
   trigger:
@@ -28,3 +23,11 @@ jobs:
           repo: mindbox-cloud/flutter-app
           ref: develop
           inputs: '{"branch": "${{ github.head_ref }}", "commits": "${{ env.commits }}"}'
+          
+      - name: Trigger build workflow in flutter-app repo
+        run: |
+          curl --location 'https://mindbox.gitlab.yandexcloud.net/api/v4/projects/900/trigger/pipeline' \
+            --form 'token="${{ secrets.GITLAB_TRIGGER_TOKEN }}"' \
+            --form 'ref="test_branch"' \
+            --form "variables[INPUT_BRANCH]=\"${{ github.head_ref }}\"" \
+            --form "variables[INPUT_COMMITS]=\"${{ env.commits }}\""

--- a/.github/workflows/trigger-build-app.yml
+++ b/.github/workflows/trigger-build-app.yml
@@ -1,11 +1,16 @@
 name: Build application after merge
 
-on: push
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - 'feature/*'
+      - 'develop'
 
 jobs:
   trigger:
     runs-on: macos-latest
-#    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -19,6 +24,6 @@ jobs:
         run: |
           curl --location 'https://mindbox.gitlab.yandexcloud.net/api/v4/projects/1056/trigger/pipeline' \
             --form 'token="${{ secrets.GITLAB_TRIGGER_TOKEN }}"' \
-            --form 'ref="test_branch"' \
+            --form 'ref="develop"' \
             --form "variables[INPUT_BRANCH]=\"${{ github.head_ref }}\"" \
             --form "variables[INPUT_COMMITS]=\"${{ env.commits }}\""

--- a/.github/workflows/trigger-build-app.yml
+++ b/.github/workflows/trigger-build-app.yml
@@ -14,15 +14,6 @@ jobs:
         run: |
           commits=$(git log -3 --pretty=format:"%s")
           echo "commits=$commits" >> $GITHUB_ENV
-
-      - name: Trigger build workflow in flutter-app repo
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          token: ${{ secrets.PAT_FLUTTER_APP }}
-          workflow: buildApplicationAfterTrigger.yml
-          repo: mindbox-cloud/flutter-app
-          ref: develop
-          inputs: '{"branch": "${{ github.head_ref }}", "commits": "${{ env.commits }}"}'
           
       - name: Trigger build workflow in flutter-app repo
         run: |

--- a/.github/workflows/trigger-build-app.yml
+++ b/.github/workflows/trigger-build-app.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Trigger build workflow in flutter-app repo
         run: |
-          curl --location 'https://mindbox.gitlab.yandexcloud.net/api/v4/projects/1056/trigger/pipeline' \
+          curl --location 'https://mindbox.gitlab.yandexcloud.net/api/v4/projects/1089/trigger/pipeline' \
             --form 'token="${{ secrets.GITLAB_TRIGGER_TOKEN }}"' \
             --form 'ref="develop"' \
             --form "variables[INPUT_BRANCH]=\"${{ github.head_ref }}\"" \

--- a/.github/workflows/trigger-build-app.yml
+++ b/.github/workflows/trigger-build-app.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           commits=$(git log -3 --pretty=format:"%s")
           echo "commits=$commits" >> $GITHUB_ENV
-          
+
       - name: Trigger build workflow in flutter-app repo
         run: |
           curl --location 'https://mindbox.gitlab.yandexcloud.net/api/v4/projects/1056/trigger/pipeline' \

--- a/.github/workflows/trigger-build-app.yml
+++ b/.github/workflows/trigger-build-app.yml
@@ -17,7 +17,7 @@ jobs:
           
       - name: Trigger build workflow in flutter-app repo
         run: |
-          curl --location 'https://mindbox.gitlab.yandexcloud.net/api/v4/projects/900/trigger/pipeline' \
+          curl --location 'https://mindbox.gitlab.yandexcloud.net/api/v4/projects/1056/trigger/pipeline' \
             --form 'token="${{ secrets.GITLAB_TRIGGER_TOKEN }}"' \
             --form 'ref="test_branch"' \
             --form "variables[INPUT_BRANCH]=\"${{ github.head_ref }}\"" \


### PR DESCRIPTION
В рамках перехода на gitlab, необходимо поменять workflow_dispatch триггер на гитлабовский аналог

- Добавлен секрет GITLAB_TRIGGER_TOKEN для триггера джобы в GitLab
- Добавлен триггер GitLab пайплайна, аналогично android-sdk и ios-sdk

Что изменится при переводе в PR:
- id проекта изменится на id импортированного проекта: 1056 -> x (на данный момент это id тестового CI/CD проекта)
