### PR TITLE
fix concurrent modification during iteration

### DIFF
--- a/mindbox_platform_interface/lib/src/types/mindbox_method_handler.dart
+++ b/mindbox_platform_interface/lib/src/types/mindbox_method_handler.dart
@@ -59,7 +59,9 @@ class MindboxMethodHandler {
                 'before initialization.');
       }
       await channel.invokeMethod('init', configuration.toMap());
-      for (final callbackMethod in _pendingCallbackMethods) {
+      final callbackMethodsCopy = 
+        List<_PendingCallbackMethod>.from(_pendingCallbackMethods);
+      for (final callbackMethod in callbackMethodsCopy) {
         callbackMethod.callback(
             await channel.invokeMethod(callbackMethod.methodName) ?? 'null');
       }


### PR DESCRIPTION
В сентри упала ошибка и при ините:

Crashed in non-app: iterable.dart in ListIterator.moveNext
mindbox_method_handler.dart in MindboxMethodHandler.init at line 62 within mindbox_platform_interface
In App
Called from: <asynchronous suspension>
mindbox_android_platform.dart in MindboxAndroidPlatform.init at line 25 within mindbox_android

У клиента Android 14, версия сдк 2.8.0, но порядок инита в новых версиях не изменился

На сколько я понял проблема в том, что инвоук метод вызывает изменение  списка ```_pendingCallbackMethods```. Возможно некорректно, что я прохожусь по перекопированну списку ```callbackMethodsCopy```, тогда надо проверять, что ```_pendingCallbackMethods``` не пуст

flutter doctor --verbose
```
!] Flutter (Channel [user-branch], 3.27.4, on macOS 15.1 24B83 darwin-arm64, locale en-US)
    ! Flutter version 3.27.4 on channel [user-branch] at /Users/equescodebelike/development/flutter
      Currently on an unknown channel. Run `flutter channel` to switch to an official channel.
      If that doesn't fix the issue, reinstall Flutter by following instructions at https://flutter.dev/setup.
    ! Upstream repository unknown source is not a standard remote.
      Set environment variable "FLUTTER_GIT_URL" to unknown source to dismiss this error.
    • Framework revision d8a9f9a52e (10 weeks ago), 2025-01-31 16:07:18 -0500
    • Engine revision 82bd5b7209
    • Dart version 3.6.2
    • DevTools version 2.40.3
    • If those were intentional, you can disregard the above warnings; however it is recommended to use "git" directly to perform update checks and
      upgrades.

[✓] Android toolchain - develop for Android devices (Android SDK version 34.0.0)
    • Android SDK at /Users/equescodebelike/Library/Android/sdk
    • Platform android-34, build-tools 34.0.0
    • Java binary at: /opt/homebrew/opt/openjdk@17/bin/java
    • Java version OpenJDK Runtime Environment Homebrew (build 17.0.14+0)
    • All Android licenses accepted.

[✓] Xcode - develop for iOS and macOS (Xcode 16.2)
    • Xcode at /Applications/Xcode.app/Contents/Developer
    • Build 16C5032a
    • CocoaPods version 1.16.2

[✓] Chrome - develop for the web
    • Chrome at /Applications/Google Chrome.app/Contents/MacOS/Google Chrome

[✓] Android Studio (version 2024.3)
    • Android Studio at /Applications/Android Studio.app/Contents
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build 21.0.5+-13047016-b750.29)

[✓] VS Code (version 1.99.1)
    • VS Code at /Applications/Visual Studio Code.app/Contents
    • Flutter extension version 3.108.0

[✓] Connected device (5 available)
    • sdk gphone64 arm64 (mobile)     • emulator-5554             • android-arm64  • Android 14 (API 34) (emulator)
    • iPhone Arkhip (mobile)          • 00008030-0003445E1EEA402E • ios            • iOS 17.1.2 21B101
    • macOS (desktop)                 • macos                     • darwin-arm64   • macOS 15.1 24B83 darwin-arm64
    • Mac Designed for iPad (desktop) • mac-designed-for-ipad     • darwin         • macOS 15.1 24B83 darwin-arm64
    • Chrome (web)                    • chrome                    • web-javascript • Google Chrome 135.0.7049.42

[✓] Network resources
    • All expected network resources are available.
```