### PR TITLE
MOBILE-222: Align flutter example App Group ID so NC shows real pushes

### DIFF
--- a/example/flutter_example/ios/MindboxNotificationServiceExtension/NotificationService.swift
+++ b/example/flutter_example/ios/MindboxNotificationServiceExtension/NotificationService.swift
@@ -10,7 +10,7 @@ import MindboxNotifications
 
 class NotificationService: UNNotificationServiceExtension {
     
-    static let suiteName = "group.cloud.Mindbox.cloud.mindbox.flutterExample"
+    static let suiteName = "group.cloud.Mindbox.mindbox.Flutter.Example"
     lazy var mindboxService = MindboxNotificationService()
     
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {

--- a/example/flutter_example/lib/view/managers/push_item_manager.dart
+++ b/example/flutter_example/lib/view/managers/push_item_manager.dart
@@ -47,7 +47,7 @@ class ItemsManager {
     }
   }
   static const int removeStartIndex = 3;
-  static const appGroupID = 'group.cloud.Mindbox.cloud.mindbox.flutterExample';
+  static const appGroupID = 'group.cloud.Mindbox.mindbox.Flutter.Example';
   ValueNotifier<List<MindboxRemoteMessage>> itemsNotifier;
 
 


### PR DESCRIPTION
The NSE suiteName and push_item_manager.dart appGroupID used group.cloud.Mindbox.cloud.mindbox.flutterExample — the App Group of the old bundle id (cloud.mindbox.flutterExample) — while the Runner/NSE/NCE entitlements use group.cloud.Mindbox.mindbox.Flutter.Example for the current bundle id (mindbox.Flutter.Example). The processes weren't entitled to their suiteName, so the shared container was empty and the notification centre showed stubs instead of received pushes. Point both at the entitled group.