### PR TITLE
MOBILE-121: Drop trailing whitespace in Gitleaks workflow

### DIFF
--- a/.github/workflows/gitleaks-secrets-validate.yml
+++ b/.github/workflows/gitleaks-secrets-validate.yml
@@ -20,4 +20,4 @@ jobs:
         uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.MINDBOX_GITLEAKS_LICENSE }} 
+          GITLEAKS_LICENSE: ${{ secrets.MINDBOX_GITLEAKS_LICENSE }}


### PR DESCRIPTION
Remove a trailing space on the last line so the Gitleaks workflow is byte-identical across ios-sdk/react-native-sdk/flutter-sdk. Whitespace-only.